### PR TITLE
Add parsing module and tests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import json
 from .memory import load_memory, save_record
 from .rag_engine import find_similar
+from .parser import parse_text
 
 app = Flask(__name__, static_folder='../static')
 
@@ -13,14 +14,14 @@ def action_plan():
     user = data.get('user', 'default')
     memory = load_memory(user)
 
-    # simple parse: split into sentences for demo
-    parts = text.split('.')
+    # parse using the dedicated parser
+    sections = parse_text(text)
     record = {
         'id': f"AP-{len(memory)+1:03d}",
-        'traceability': parts[0].strip() if parts else '',
-        'problem': parts[1].strip() if len(parts) > 1 else '',
-        'cause': parts[2].strip() if len(parts) > 2 else '',
-        'action': parts[3].strip() if len(parts) > 3 else '',
+        'traceability': sections.get('traceability', ''),
+        'problem': sections.get('problem', ''),
+        'cause': sections.get('cause', ''),
+        'action': sections.get('action', ''),
         'responsible': '',
         'date': '',
         'effectiveness': '',

--- a/app/parser.py
+++ b/app/parser.py
@@ -1,0 +1,30 @@
+import re
+
+LABEL_RE = re.compile(r'(traceability|problem|cause|action)\s*[:\-]\s*', re.IGNORECASE)
+
+
+def parse_text(text: str) -> dict:
+    """Parse raw input text into structured sections.
+
+    The function first looks for explicit labels like ``Traceability:``,
+    ``Problem:``, etc. When no labels are found, it falls back to
+    sentence-based splitting using regex to recognise sentence boundaries.
+    """
+    sections = {"traceability": "", "problem": "", "cause": "", "action": ""}
+
+    matches = list(LABEL_RE.finditer(text))
+    if matches:
+        for idx, match in enumerate(matches):
+            label = match.group(1).lower()
+            start = match.end()
+            end = matches[idx + 1].start() if idx + 1 < len(matches) else len(text)
+            part = text[start:end].strip()
+            sections[label] = part.rstrip(" .;!-?")
+        return sections
+
+    # fallback: split by sentence boundaries
+    sentences = [s.strip() for s in re.split(r'(?<=[.!?])\s+', text) if s.strip()]
+    keys = ["traceability", "problem", "cause", "action"]
+    for key, sentence in zip(keys, sentences):
+        sections[key] = sentence.rstrip(" .;!?")
+    return sections

--- a/tests/test_action_plan.py
+++ b/tests/test_action_plan.py
@@ -1,5 +1,11 @@
 import json
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 from app.main import app
+from app.parser import parse_text
 
 
 def test_action_plan_post():
@@ -12,3 +18,24 @@ def test_action_plan_post():
     data = json.loads(response.data)
     assert 'id' in data
     assert 'problem' in data
+
+
+def test_parse_multi_sentence():
+    text = (
+        "Traceability: TR01. Problem: Something is wrong. It fails! "
+        "Cause: Unknown. Action: Restart system."
+    )
+    result = parse_text(text)
+    assert result['traceability'] == 'TR01'
+    assert result['problem'] == 'Something is wrong. It fails!'
+    assert result['cause'] == 'Unknown'
+    assert result['action'] == 'Restart system'
+
+
+def test_parse_edge_punctuation():
+    text = "Traceability - TR02? Problem - gear stuck! Cause - worn part. Action - replace it." 
+    result = parse_text(text)
+    assert result['traceability'] == 'TR02'
+    assert result['problem'] == 'gear stuck!'
+    assert result['cause'] == 'worn part'
+    assert result['action'] == 'replace it'


### PR DESCRIPTION
## Summary
- add `parser.py` implementing regex-based extraction of traceability, problem, cause and action
- hook parser into the `/action_plan` endpoint
- extend tests with multi-sentence and punctuation parsing cases

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_68797a2bd7cc8322913fc2891fffac54