### PR TITLE
Implement duplicate detection update logic

### DIFF
--- a/app/memory.py
+++ b/app/memory.py
@@ -25,3 +25,11 @@ def save_record(user: str, record: dict):
     path = get_memory_path(user)
     with open(path, 'a', encoding='utf-8') as f:
         f.write(json.dumps(record, ensure_ascii=False) + '\n')
+
+
+def save_memory(user: str, records: list):
+    """Rewrite the entire memory file with the provided records."""
+    path = get_memory_path(user)
+    with open(path, 'w', encoding='utf-8') as f:
+        for rec in records:
+            f.write(json.dumps(rec, ensure_ascii=False) + '\n')

--- a/app/rag_engine.py
+++ b/app/rag_engine.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Tuple
 
 
 def tokenize(text: str):
@@ -12,15 +12,24 @@ def jaccard(s1: set, s2: set) -> float:
     return len(s1 & s2) / len(s1 | s2)
 
 
-def find_similar(record: Dict, memory: List[Dict]) -> Optional[Dict]:
+def find_similar(record: Dict, memory: List[Dict]) -> Tuple[Optional[Dict], float]:
+    """Return the most similar record from memory and its similarity score.
+
+    The similarity is computed using Jaccard distance on tokenized problem
+    descriptions. If the best score is below ``0.5`` no record is considered a
+    valid match and ``None`` is returned for the record.
+    """
+
     tokens = tokenize(record.get('problem', ''))
     best = None
     best_score = 0.0
+
     for r in memory:
         score = jaccard(tokens, tokenize(r.get('problem', '')))
         if score > best_score:
             best_score = score
             best = r
+
     if best_score > 0.5:
-        return best
-    return None
+        return best, best_score
+    return None, best_score

--- a/tests/test_action_plan.py
+++ b/tests/test_action_plan.py
@@ -16,8 +16,8 @@ def test_action_plan_post():
     })
     assert response.status_code == 200
     data = json.loads(response.data)
-    assert 'id' in data
-    assert 'problem' in data
+    assert 'record' in data
+    assert 'id' in data['record']
 
 
 def test_parse_multi_sentence():
@@ -33,9 +33,35 @@ def test_parse_multi_sentence():
 
 
 def test_parse_edge_punctuation():
-    text = "Traceability - TR02? Problem - gear stuck! Cause - worn part. Action - replace it." 
+    text = "Traceability - TR02? Problem - gear stuck! Cause - worn part. Action - replace it."
     result = parse_text(text)
     assert result['traceability'] == 'TR02'
     assert result['problem'] == 'gear stuck!'
     assert result['cause'] == 'worn part'
     assert result['action'] == 'replace it'
+
+
+def test_duplicate_detection(tmp_path):
+    user = 'dup_test'
+    mem_dir = tmp_path / 'memory'
+    os.makedirs(mem_dir / user)
+    # patch memory directory in app.memory for test
+    from app import memory as memory_mod
+    old_dir = memory_mod.MEMORY_DIR
+    memory_mod.MEMORY_DIR = mem_dir
+
+    client = app.test_client()
+    text1 = 'Traceability: TR01. Problem: lever stuck. Cause: unknown. Action: fix.'
+    text2 = 'Traceability: TR01. Problem: lever stuck. Cause: rust. Action: grease.'
+
+    r1 = client.post('/action_plan', json={'text': text1, 'user': user})
+    assert r1.status_code == 200
+    r2 = client.post('/action_plan', json={'text': text2, 'user': user})
+    assert r2.status_code == 200
+
+    memory = memory_mod.load_memory(user)
+    assert len(memory) == 1
+    assert memory[0]['cause'] == 'rust'
+
+    # restore original directory
+    memory_mod.MEMORY_DIR = old_dir


### PR DESCRIPTION
## Summary
- expose similarity score from `find_similar`
- support rewriting memory and update threshold logic
- avoid saving duplicate records in `/action_plan`
- test duplicate detection and updated response format

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_687981eff7848322b58cee7e7acee5fc